### PR TITLE
Temporary fix for addPetToOwner, making the pet's name mandatory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <groupId>org.springframework.samples</groupId>
-  <artifactId>spring-petclinic</artifactId>
+  <artifactId>spring-petclinic-langchain4j</artifactId>
   <version>3.4.0-SNAPSHOT</version>
 
   <name>petclinic</name>

--- a/src/main/java/org/springframework/samples/petclinic/chat/AssistantTool.java
+++ b/src/main/java/org/springframework/samples/petclinic/chat/AssistantTool.java
@@ -48,7 +48,10 @@ public class AssistantTool {
 	@Tool("Add a pet with the specified petTypeId, to an owner identified by the ownerId")
 	public AddedPetResponse addPetToOwner(AddPetRequest request) {
 		Owner owner = ownerRepository.findById(request.ownerId()).orElseThrow();
-		owner.addPet(request.pet());
+		// Waiting for https://github.com/langchain4j/langchain4j/issues/2249
+		Pet pet = request.pet();
+		pet.setName(request.petName());
+		owner.addPet(pet);
 		this.ownerRepository.save(owner);
 		return new AddedPetResponse(owner);
 	}
@@ -69,7 +72,7 @@ public class AssistantTool {
 
 }
 
-record AddPetRequest(Pet pet, Integer ownerId) {
+record AddPetRequest(Pet pet, String petName, Integer ownerId) {
 }
 
 record OwnerRequest(Owner owner) {


### PR DESCRIPTION
Fix assistant behavior by answering the question: 
> Add a dog for Betty. Its name is Moopsie. His birthday is on 2 October 2024.

Waiting for https://github.com/langchain4j/langchain4j/issues/2249